### PR TITLE
#33-Date포맷 수정

### DIFF
--- a/app/src/main/java/me/jy/danggi/activities/MainActivity.java
+++ b/app/src/main/java/me/jy/danggi/activities/MainActivity.java
@@ -120,7 +120,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private Date convertDateFormat ( String dateTime ) { //데이터베이스에 저장된 String을 다시 Date로 ? 이것도 꽤 비효율적인듯
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm", Locale.getDefault());
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault());
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         try {
             return dateFormat.parse(dateTime);

--- a/app/src/main/java/me/jy/danggi/binding/BindingConverts.java
+++ b/app/src/main/java/me/jy/danggi/binding/BindingConverts.java
@@ -14,9 +14,6 @@ public class BindingConverts {
 
     @BindingConversion
     public static String convertDate(Date date) {
-        if (date !=null)
             return new SimpleDateFormat("yyyy년 MM월 dd일 HH:mm", Locale.KOREAN).format(date);
-    else
-        return "-1";
     }
 }


### PR DESCRIPTION
메모 저장시에는 12시간 기준의 시간이, 수정 후에는 24시간 기준의 시간이 표시되는 이슈가 있었음.

DB의 시간데이터를 불러와서 다시 Date타입으로 만들 때, 지정한 포맷이 잘못되었음.
hh -> HH로 변경함